### PR TITLE
allow for immediate 'confirmed' message when using high tx speed

### DIFF
--- a/app/assets/javascripts/spree/frontend/spree_bitpay.js
+++ b/app/assets/javascripts/spree/frontend/spree_bitpay.js
@@ -17,14 +17,14 @@ var Bitpay = {
       switch(message.data.status) {
         case "new":
           break;
-        case "paid":
+        case "paid", "confirmed":
           Bitpay.continueToConfirmation();
           break;
         case "expired":
           Bitpay.showExpiredMessage();
           break;
         default:
-          console.log("Unexpected message type.")
+          console.log("Unexpected message type: " + message.data.status)
       }
     }
     return false;


### PR DESCRIPTION
For transaction speed "high" the window.message goes directly to "confirmed" rather than "paid" - this change allows for proper operation in this scenario and also adds a more effective debug message in the event an unexpected status is received.
